### PR TITLE
Add foreword mapping the translators and the stories they worked on

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -187,6 +187,8 @@
 		<item href="text/colophon.xhtml" id="colophon.xhtml" media-type="application/xhtml+xml" properties="svg"/>
 		<item href="text/dies-irae.xhtml" id="dies-irae.xhtml" media-type="application/xhtml+xml"/>
 		<item href="text/endnotes.xhtml" id="endnotes.xhtml" media-type="application/xhtml+xml"/>
+		<item href="text/foreword.xhtml" id="foreword.xhtml" media-type="application/xhtml+xml"/>
+		<item href="text/halftitle.xhtml" id="halftitle.xhtml" media-type="application/xhtml+xml"/>
 		<item href="text/his-excellency-the-governor.xhtml" id="his-excellency-the-governor.xhtml" media-type="application/xhtml+xml"/>
 		<item href="text/imprint.xhtml" id="imprint.xhtml" media-type="application/xhtml+xml" properties="svg"/>
 		<item href="text/in-the-basement.xhtml" id="in-the-basement.xhtml" media-type="application/xhtml+xml"/>
@@ -224,6 +226,8 @@
 	<spine>
 		<itemref idref="titlepage.xhtml"/>
 		<itemref idref="imprint.xhtml"/>
+		<itemref idref="foreword.xhtml"/>
+		<itemref idref="halftitle.xhtml"/>
 		<itemref idref="bargamot-and-garaska.xhtml"/>
 		<itemref idref="the-little-angel.xhtml"/>
 		<itemref idref="petka-at-the-bungalow.xhtml"/>

--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -9,6 +9,10 @@ footer{
 	margin-top: 1em;
 }
 
+[epub|type~="foreword"] footer{
+	text-align: right;
+}
+
 span[epub|type~="subtitle"]{
 	display: block;
 	font-weight: normal;

--- a/src/epub/text/foreword.xhtml
+++ b/src/epub/text/foreword.xhtml
@@ -9,6 +9,10 @@
 		<section id="foreword" epub:type="foreword z3998:editorial-note">
 			<h2 epub:type="title">Foreword</h2>
 			<p>This edition of Leonid Andreyev’s <i epub:type="se:name.publication.book">Short Fiction</i> was produced from various translations. “The Red Laugh” was translated by Alexandra Linden and originally published in 1905. “The Seven Who Were Hanged” was translated by Herman Bernstein and originally published in 1909. “A Dilemma” was translated by John Cournos and originally published in 1910. “The Wall” was translated by <abbr class="name">W. H.</abbr> Lowe and also originally published in 1910. “The Crushed Flower”, “A Story Which Will Never Be Finished”, “On the Day of the Crucifixion”, “Love, Faith and Hope”, “The Ocean”, and “The Man Who Found the Truth” were also translated by Herman Bernstein and originally published in 1916. “The Little Angel”, “At the Roadside Station”, “Snapper”, “The Lie”, “An Original”, “Petka at the Bungalow”, “Silence”, “Laughter”, “The Friend”, “In the Basement”, “The City”, “The Tocsin”, “Bargamot and Garaska”, “Men May Rise on Stepping-Stones of Their Dead Selves to Higher Things” and “The Spy” were also translated by <abbr class="name">W. H.</abbr> Lowe and also originally published in 1916. “A Present”, “The Giant” and “The Story of the Snake” were translated by <i epub:type="se:name.publiation.magazine">The Russian Review</i> and also originally published in 1916. “The Confessions of a Little Man During Great Days” was translated by <abbr class="name">R. S.</abbr> Townsend and originally published in 1917. “When the King Loses His Head”, “Judas Iscariot”, “Lazarus”, “Life of Father Vassily”, “The Marseillaise” and “Dies Irae” were translated by Archibald <abbr class="name">J.</abbr> Wolfe and originally published in 1919. “His Excellency the Governor” was translated by Maurice Magnus and originally published in 1921. “The Dark the Governor” was translated by <abbr class="name">L. A.</abbr> Magnus and <abbr class="name">K.</abbr> Walter, and originally published in 1922.</p>
+			<footer>
+				<p>Robin Whittleton</p>
+				<p>Malmö, Sweden, 2019</p>
+			</footer>
 		</section>
 	</body>
 </html>

--- a/src/epub/text/foreword.xhtml
+++ b/src/epub/text/foreword.xhtml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
+	<head>
+		<title>Foreword</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="frontmatter z3998:non-fiction">
+		<section id="foreword" epub:type="foreword z3998:editorial-note">
+			<h2 epub:type="title">Foreword</h2>
+			<p>This edition of Leonid Andreyev’s <i epub:type="se:name.publication.book">Short Fiction</i> was produced from various translations. “The Red Laugh” was translated by Alexandra Linden and originally published in 1905. “The Seven Who Were Hanged” was translated by Herman Bernstein and originally published in 1909. “A Dilemma” was translated by John Cournos and originally published in 1910. “The Wall” was translated by <abbr class="name">W. H.</abbr> Lowe and also originally published in 1910. “The Crushed Flower”, “A Story Which Will Never Be Finished”, “On the Day of the Crucifixion”, “Love, Faith and Hope”, “The Ocean”, and “The Man Who Found the Truth” were also translated by Herman Bernstein and originally published in 1916. “The Little Angel”, “At the Roadside Station”, “Snapper”, “The Lie”, “An Original”, “Petka at the Bungalow”, “Silence”, “Laughter”, “The Friend”, “In the Basement”, “The City”, “The Tocsin”, “Bargamot and Garaska”, “Men May Rise on Stepping-Stones of Their Dead Selves to Higher Things” and “The Spy” were also translated by <abbr class="name">W. H.</abbr> Lowe and also originally published in 1916. “A Present”, “The Giant” and “The Story of the Snake” were translated by <i epub:type="se:name.publiation.magazine">The Russian Review</i> and also originally published in 1916. “The Confessions of a Little Man During Great Days” was translated by <abbr class="name">R. S.</abbr> Townsend and originally published in 1917. “When the King Loses His Head”, “Judas Iscariot”, “Lazarus”, “Life of Father Vassily”, “The Marseillaise” and “Dies Irae” were translated by Archibald <abbr class="name">J.</abbr> Wolfe and originally published in 1919. “His Excellency the Governor” was translated by Maurice Magnus and originally published in 1921. “The Dark the Governor” was translated by <abbr class="name">L. A.</abbr> Magnus and <abbr class="name">K.</abbr> Walter, and originally published in 1922.</p>
+		</section>
+	</body>
+</html>

--- a/src/epub/text/halftitle.xhtml
+++ b/src/epub/text/halftitle.xhtml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-US">
+	<head>
+		<title>Half Title</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="frontmatter">
+		<section id="halftitlepage" epub:type="halftitlepage">
+			<h1 epub:type="fulltitle">
+				<span epub:type="title">Short Fiction</span>
+			</h1>
+		</section>
+	</body>
+</html>

--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -14,743 +14,751 @@
 					<a href="text/imprint.xhtml">Imprint</a>
 				</li>
 				<li>
-					<a href="text/bargamot-and-garaska.xhtml">Bargamot and Garaska</a>
+					<a href="text/foreword.xhtml">Foreword</a>
 				</li>
 				<li>
-					<a href="text/the-little-angel.xhtml">The Little Angel</a>
+					<a href="text/halftitle.xhtml">Short Fiction</a>
 					<ol>
 						<li>
-							<a href="text/the-little-angel.xhtml#the-little-angel-1" epub:type="z3998:roman">I</a>
+							<a href="text/bargamot-and-garaska.xhtml">Bargamot and Garaska</a>
 						</li>
 						<li>
-							<a href="text/the-little-angel.xhtml#the-little-angel-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/the-little-angel.xhtml#the-little-angel-3" epub:type="z3998:roman">III</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/petka-at-the-bungalow.xhtml">Petka at the Bungalow</a>
-				</li>
-				<li>
-					<a href="text/the-friend.xhtml">The Friend</a>
-				</li>
-				<li>
-					<a href="text/the-lie.xhtml">The Lie</a>
-					<ol>
-						<li>
-							<a href="text/the-lie.xhtml#the-lie-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/the-lie.xhtml#the-lie-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/the-lie.xhtml#the-lie-3" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/the-lie.xhtml#the-lie-4" epub:type="z3998:roman">IV</a>
-						</li>
-						<li>
-							<a href="text/the-lie.xhtml#the-lie-5" epub:type="z3998:roman">V</a>
-						</li>
-						<li>
-							<a href="text/the-lie.xhtml#the-lie-6" epub:type="z3998:roman">VI</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/silence.xhtml">Silence</a>
-					<ol>
-						<li>
-							<a href="text/silence.xhtml#silence-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/silence.xhtml#silence-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/silence.xhtml#silence-3" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/silence.xhtml#silence-4" epub:type="z3998:roman">IV</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/men-may-rise-on-stepping-stones-of-their-dead-selves-to-higher-things.xhtml">“Men May Rise on Stepping-Stones of Their Dead Selves to Higher Things”</a>
-				</li>
-				<li>
-					<a href="text/the-wall.xhtml">The Wall</a>
-					<ol>
-						<li>
-							<a href="text/the-wall.xhtml#the-wall-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/the-wall.xhtml#the-wall-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/the-wall.xhtml#the-wall-3" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/the-wall.xhtml#the-wall-4" epub:type="z3998:roman">IV</a>
-						</li>
-						<li>
-							<a href="text/the-wall.xhtml#the-wall-5" epub:type="z3998:roman">V</a>
-						</li>
-						<li>
-							<a href="text/the-wall.xhtml#the-wall-6" epub:type="z3998:roman">VI</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/snapper.xhtml">Snapper</a>
-					<ol>
-						<li>
-							<a href="text/snapper.xhtml#snapper-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/snapper.xhtml#snapper-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/snapper.xhtml#snapper-3" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/snapper.xhtml#snapper-4" epub:type="z3998:roman">IV</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/laughter.xhtml">Laughter</a>
-					<ol>
-						<li>
-							<a href="text/laughter.xhtml#laughter-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/laughter.xhtml#laughter-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/laughter.xhtml#laughter-3" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/laughter.xhtml#laughter-4" epub:type="z3998:roman">IV</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/in-the-basement.xhtml">In the Basement</a>
-					<ol>
-						<li>
-							<a href="text/in-the-basement.xhtml#in-the-basement-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/in-the-basement.xhtml#in-the-basement-2" epub:type="z3998:roman">II</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/the-tocsin.xhtml">The Tocsin</a>
-					<ol>
-						<li>
-							<a href="text/the-tocsin.xhtml#the-tocsin-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/the-tocsin.xhtml#the-tocsin-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/the-tocsin.xhtml#the-tocsin-3" epub:type="z3998:roman">III</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/a-present.xhtml">A Present</a>
-					<ol>
-						<li>
-							<a href="text/a-present.xhtml#a-present-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/a-present.xhtml#a-present-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/a-present.xhtml#a-present-3" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/a-present.xhtml#a-present-4" epub:type="z3998:roman">IV</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/a-dilemma.xhtml">A Dilemma</a>
-					<ol>
-						<li>
-							<a href="text/a-dilemma.xhtml#a-dilemma-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/a-dilemma.xhtml#a-dilemma-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/a-dilemma.xhtml#a-dilemma-3" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/a-dilemma.xhtml#a-dilemma-4" epub:type="z3998:roman">IV</a>
-						</li>
-						<li>
-							<a href="text/a-dilemma.xhtml#a-dilemma-5" epub:type="z3998:roman">V</a>
-						</li>
-						<li>
-							<a href="text/a-dilemma.xhtml#a-dilemma-6" epub:type="z3998:roman">VI</a>
-						</li>
-						<li>
-							<a href="text/a-dilemma.xhtml#a-dilemma-7" epub:type="z3998:roman">VII</a>
-						</li>
-						<li>
-							<a href="text/a-dilemma.xhtml#a-dilemma-8" epub:type="z3998:roman">VIII</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/an-original.xhtml">An Original</a>
-				</li>
-				<li>
-					<a href="text/the-city.xhtml">The City</a>
-				</li>
-				<li>
-					<a href="text/on-the-day-of-the-crucifixion.xhtml">On the Day of the Crucifixion</a>
-				</li>
-				<li>
-					<a href="text/at-the-roadside-station.xhtml">At the Roadside Station</a>
-				</li>
-				<li>
-					<a href="text/life-of-father-vassily.xhtml">Life of Father Vassily</a>
-					<ol>
-						<li>
-							<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-3" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-4" epub:type="z3998:roman">IV</a>
-						</li>
-						<li>
-							<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-5" epub:type="z3998:roman">V</a>
-						</li>
-						<li>
-							<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-6" epub:type="z3998:roman">VI</a>
-						</li>
-						<li>
-							<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-7" epub:type="z3998:roman">VII</a>
-						</li>
-						<li>
-							<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-8" epub:type="z3998:roman">VIII</a>
-						</li>
-						<li>
-							<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-9" epub:type="z3998:roman">IX</a>
-						</li>
-						<li>
-							<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-10" epub:type="z3998:roman">X</a>
-						</li>
-						<li>
-							<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-11" epub:type="z3998:roman">XI</a>
-						</li>
-						<li>
-							<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-12" epub:type="z3998:roman">XII</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/the-marseillaise.xhtml">The Marseillaise</a>
-				</li>
-				<li>
-					<a href="text/the-red-laugh.xhtml">The Red Laugh</a>
-					<ol>
-						<li>
-							<a href="text/the-red-laugh.xhtml#the-red-laugh-1">Part <span epub:type="z3998:roman">I</span></a>
+							<a href="text/the-little-angel.xhtml">The Little Angel</a>
 							<ol>
 								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-1-1">Fragment <span epub:type="z3998:roman">I</span></a>
+									<a href="text/the-little-angel.xhtml#the-little-angel-1" epub:type="z3998:roman">I</a>
 								</li>
 								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-1-2">Fragment <span epub:type="z3998:roman">II</span></a>
+									<a href="text/the-little-angel.xhtml#the-little-angel-2" epub:type="z3998:roman">II</a>
 								</li>
 								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-1-3">Fragment <span epub:type="z3998:roman">III</span></a>
-								</li>
-								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-1-4">Fragment <span epub:type="z3998:roman">IV</span></a>
-								</li>
-								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-1-5">Fragment <span epub:type="z3998:roman">V</span></a>
-								</li>
-								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-1-6">Fragment <span epub:type="z3998:roman">VI</span></a>
-								</li>
-								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-1-7">Fragment <span epub:type="z3998:roman">VII</span></a>
-								</li>
-								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-1-8">Fragment <span epub:type="z3998:roman">VIII</span></a>
-								</li>
-								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-1-9">Fragment <span epub:type="z3998:roman">IX</span></a>
+									<a href="text/the-little-angel.xhtml#the-little-angel-3" epub:type="z3998:roman">III</a>
 								</li>
 							</ol>
 						</li>
 						<li>
-							<a href="text/the-red-laugh.xhtml#the-red-laugh-2">Part <span epub:type="z3998:roman">II</span></a>
+							<a href="text/petka-at-the-bungalow.xhtml">Petka at the Bungalow</a>
+						</li>
+						<li>
+							<a href="text/the-friend.xhtml">The Friend</a>
+						</li>
+						<li>
+							<a href="text/the-lie.xhtml">The Lie</a>
 							<ol>
 								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-2-10">Fragment <span epub:type="z3998:roman">X</span></a>
+									<a href="text/the-lie.xhtml#the-lie-1" epub:type="z3998:roman">I</a>
 								</li>
 								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-2-11">Fragment <span epub:type="z3998:roman">XI</span></a>
+									<a href="text/the-lie.xhtml#the-lie-2" epub:type="z3998:roman">II</a>
 								</li>
 								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-2-12">Fragment <span epub:type="z3998:roman">XII</span></a>
+									<a href="text/the-lie.xhtml#the-lie-3" epub:type="z3998:roman">III</a>
 								</li>
 								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-2-13">Fragment <span epub:type="z3998:roman">XIII</span></a>
+									<a href="text/the-lie.xhtml#the-lie-4" epub:type="z3998:roman">IV</a>
 								</li>
 								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-2-14">Fragment <span epub:type="z3998:roman">XIV</span></a>
+									<a href="text/the-lie.xhtml#the-lie-5" epub:type="z3998:roman">V</a>
 								</li>
 								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-2-15">Fragment <span epub:type="z3998:roman">XV</span></a>
-								</li>
-								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-2-16">Fragment <span epub:type="z3998:roman">XVI</span></a>
-								</li>
-								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-2-17">Fragment <span epub:type="z3998:roman">XVII</span></a>
-								</li>
-								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-2-18">Fragment <span epub:type="z3998:roman">XVIII</span></a>
-								</li>
-								<li>
-									<a href="text/the-red-laugh.xhtml#the-red-laugh-2-19">Fragment the Last</a>
-								</li>
-							</ol>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/the-spy.xhtml">The Spy</a>
-				</li>
-				<li>
-					<a href="text/when-the-king-loses-his-head.xhtml">When the King Loses His Head</a>
-					<ol>
-						<li>
-							<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-3" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-4" epub:type="z3998:roman">IV</a>
-						</li>
-						<li>
-							<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-5" epub:type="z3998:roman">V</a>
-						</li>
-						<li>
-							<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-6" epub:type="z3998:roman">VI</a>
-						</li>
-						<li>
-							<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-7" epub:type="z3998:roman">VII</a>
-						</li>
-						<li>
-							<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-8" epub:type="z3998:roman">VIII</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/his-excellency-the-governor.xhtml">His Excellency the Governor</a>
-					<ol>
-						<li>
-							<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-3" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-4" epub:type="z3998:roman">IV</a>
-						</li>
-						<li>
-							<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-5" epub:type="z3998:roman">V</a>
-						</li>
-						<li>
-							<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-6" epub:type="z3998:roman">VI</a>
-						</li>
-						<li>
-							<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-7" epub:type="z3998:roman">VII</a>
-						</li>
-						<li>
-							<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-8" epub:type="z3998:roman">VIII</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/lazarus.xhtml">Lazarus</a>
-					<ol>
-						<li>
-							<a href="text/lazarus.xhtml#lazarus-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/lazarus.xhtml#lazarus-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/lazarus.xhtml#lazarus-3" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/lazarus.xhtml#lazarus-4" epub:type="z3998:roman">IV</a>
-						</li>
-						<li>
-							<a href="text/lazarus.xhtml#lazarus-5" epub:type="z3998:roman">V</a>
-						</li>
-						<li>
-							<a href="text/lazarus.xhtml#lazarus-6" epub:type="z3998:roman">VI</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/judas-iscariot.xhtml">Judas Iscariot</a>
-					<ol>
-						<li>
-							<a href="text/judas-iscariot.xhtml#judas-iscariot-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/judas-iscariot.xhtml#judas-iscariot-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/judas-iscariot.xhtml#judas-iscariot-3" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/judas-iscariot.xhtml#judas-iscariot-4" epub:type="z3998:roman">IV</a>
-						</li>
-						<li>
-							<a href="text/judas-iscariot.xhtml#judas-iscariot-5" epub:type="z3998:roman">V</a>
-						</li>
-						<li>
-							<a href="text/judas-iscariot.xhtml#judas-iscariot-6" epub:type="z3998:roman">VI</a>
-						</li>
-						<li>
-							<a href="text/judas-iscariot.xhtml#judas-iscariot-7" epub:type="z3998:roman">VII</a>
-						</li>
-						<li>
-							<a href="text/judas-iscariot.xhtml#judas-iscariot-8" epub:type="z3998:roman">VIII</a>
-						</li>
-						<li>
-							<a href="text/judas-iscariot.xhtml#judas-iscariot-9" epub:type="z3998:roman">IX</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/the-dark.xhtml">The Dark</a>
-					<ol>
-						<li>
-							<a href="text/the-dark.xhtml#the-dark-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/the-dark.xhtml#the-dark-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/the-dark.xhtml#the-dark-3" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/the-dark.xhtml#the-dark-6" epub:type="z3998:roman">VI</a>
-						</li>
-						<li>
-							<a href="text/the-dark.xhtml#the-dark-7" epub:type="z3998:roman">VII</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/the-seven-who-were-hanged.xhtml">The Seven Who Were Hanged</a>
-					<ol>
-						<li>
-							<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-1"><span epub:type="z3998:roman">I</span>: At One O’clock, Your Excellency!</a>
-						</li>
-						<li>
-							<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-2"><span epub:type="z3998:roman">II</span>: Condemned to Be Hanged</a>
-						</li>
-						<li>
-							<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-3"><span epub:type="z3998:roman">III</span>: Why Should I Be Hanged?</a>
-						</li>
-						<li>
-							<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-4"><span epub:type="z3998:roman">IV</span>: We Come from Oryol</a>
-						</li>
-						<li>
-							<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-5"><span epub:type="z3998:roman">V</span>: Kiss⁠—And Say Nothing</a>
-						</li>
-						<li>
-							<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-6"><span epub:type="z3998:roman">VI</span>: The Hours Are Rushing</a>
-						</li>
-						<li>
-							<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-7"><span epub:type="z3998:roman">VII</span>: There Is No Death</a>
-						</li>
-						<li>
-							<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-8"><span epub:type="z3998:roman">VIII</span>: There Is Death as Well as Life</a>
-						</li>
-						<li>
-							<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-9"><span epub:type="z3998:roman">IX</span>: Dreadful Solitude</a>
-						</li>
-						<li>
-							<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-10"><span epub:type="z3998:roman">X</span>: The Walls Are Falling</a>
-						</li>
-						<li>
-							<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-11"><span epub:type="z3998:roman">XI</span>: On the Way to the Scaffold</a>
-						</li>
-						<li>
-							<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-12"><span epub:type="z3998:roman">XII</span>: They Are Hanged</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/a-story-which-will-never-be-finished.xhtml">A Story Which Will Never Be Finished</a>
-				</li>
-				<li>
-					<a href="text/the-giant.xhtml">The Giant</a>
-				</li>
-				<li>
-					<a href="text/love-faith-and-hope.xhtml">Love, Faith and Hope</a>
-				</li>
-				<li>
-					<a href="text/the-man-who-found-the-truth.xhtml">“The Man Who Found the Truth”</a>
-					<ol>
-						<li>
-							<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-3" epub:type="z3998:roman">III</a>
-						</li>
-						<li>
-							<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-4" epub:type="z3998:roman">IV</a>
-						</li>
-						<li>
-							<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-5" epub:type="z3998:roman">V</a>
-						</li>
-						<li>
-							<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-6" epub:type="z3998:roman">VI</a>
-						</li>
-						<li>
-							<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-7" epub:type="z3998:roman">VII</a>
-						</li>
-						<li>
-							<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-8" epub:type="z3998:roman">VIII</a>
-						</li>
-						<li>
-							<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-9" epub:type="z3998:roman">IX</a>
-						</li>
-						<li>
-							<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-10" epub:type="z3998:roman">X</a>
-						</li>
-						<li>
-							<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-11" epub:type="z3998:roman">XI</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/the-story-of-the-snake.xhtml">The Story of the Snake</a>
-				</li>
-				<li>
-					<a href="text/dies-irae.xhtml">Dies Irae</a>
-					<ol>
-						<li>
-							<a href="text/dies-irae.xhtml#dies-irae-1">Chant the First</a>
-							<ol>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-1-1" epub:type="z3998:roman">I</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-1-2" epub:type="z3998:roman">II</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-1-3" epub:type="z3998:roman">III</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-1-4" epub:type="z3998:roman">IV</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-1-5" epub:type="z3998:roman">V</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-1-6" epub:type="z3998:roman">VI</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-1-7" epub:type="z3998:roman">VII</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-1-8" epub:type="z3998:roman">VIII</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-1-9" epub:type="z3998:roman">IX</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-1-10" epub:type="z3998:roman">X</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-1-11" epub:type="z3998:roman">XI</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-1-12" epub:type="z3998:roman">XII</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-1-13" epub:type="z3998:roman">XIII</a>
+									<a href="text/the-lie.xhtml#the-lie-6" epub:type="z3998:roman">VI</a>
 								</li>
 							</ol>
 						</li>
 						<li>
-							<a href="text/dies-irae.xhtml#dies-irae-2">Chant the Second</a>
+							<a href="text/silence.xhtml">Silence</a>
 							<ol>
 								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-1" epub:type="z3998:roman">I</a>
+									<a href="text/silence.xhtml#silence-1" epub:type="z3998:roman">I</a>
 								</li>
 								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-2" epub:type="z3998:roman">II</a>
+									<a href="text/silence.xhtml#silence-2" epub:type="z3998:roman">II</a>
 								</li>
 								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-3" epub:type="z3998:roman">III</a>
+									<a href="text/silence.xhtml#silence-3" epub:type="z3998:roman">III</a>
 								</li>
 								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-4" epub:type="z3998:roman">IV</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-5" epub:type="z3998:roman">V</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-6" epub:type="z3998:roman">VI</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-7" epub:type="z3998:roman">VII</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-8" epub:type="z3998:roman">VIII</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-9" epub:type="z3998:roman">IX</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-10" epub:type="z3998:roman">X</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-11" epub:type="z3998:roman">XI</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-12" epub:type="z3998:roman">XII</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-13" epub:type="z3998:roman">XIII</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-14" epub:type="z3998:roman">XIV</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-15" epub:type="z3998:roman">XV</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-16" epub:type="z3998:roman">XVI</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-17" epub:type="z3998:roman">XVII</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-18" epub:type="z3998:roman">XVIII</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-19" epub:type="z3998:roman">XIX</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-20" epub:type="z3998:roman">XX</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-21" epub:type="z3998:roman">XXI</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-22" epub:type="z3998:roman">XXII</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-23" epub:type="z3998:roman">XXIII</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-24" epub:type="z3998:roman">XXIV</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-25" epub:type="z3998:roman">XXV</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-26" epub:type="z3998:roman">XXVI</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-27" epub:type="z3998:roman">XXVII</a>
-								</li>
-								<li>
-									<a href="text/dies-irae.xhtml#dies-irae-2-28" epub:type="z3998:roman">XXVIII</a>
+									<a href="text/silence.xhtml#silence-4" epub:type="z3998:roman">IV</a>
 								</li>
 							</ol>
 						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/the-ocean.xhtml">The Ocean</a>
-					<ol>
 						<li>
-							<a href="text/the-ocean.xhtml#the-ocean-1" epub:type="z3998:roman">I</a>
+							<a href="text/men-may-rise-on-stepping-stones-of-their-dead-selves-to-higher-things.xhtml">“Men May Rise on Stepping-Stones of Their Dead Selves to Higher Things”</a>
 						</li>
 						<li>
-							<a href="text/the-ocean.xhtml#the-ocean-2" epub:type="z3998:roman">II</a>
+							<a href="text/the-wall.xhtml">The Wall</a>
+							<ol>
+								<li>
+									<a href="text/the-wall.xhtml#the-wall-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/the-wall.xhtml#the-wall-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/the-wall.xhtml#the-wall-3" epub:type="z3998:roman">III</a>
+								</li>
+								<li>
+									<a href="text/the-wall.xhtml#the-wall-4" epub:type="z3998:roman">IV</a>
+								</li>
+								<li>
+									<a href="text/the-wall.xhtml#the-wall-5" epub:type="z3998:roman">V</a>
+								</li>
+								<li>
+									<a href="text/the-wall.xhtml#the-wall-6" epub:type="z3998:roman">VI</a>
+								</li>
+							</ol>
 						</li>
 						<li>
-							<a href="text/the-ocean.xhtml#the-ocean-3" epub:type="z3998:roman">III</a>
+							<a href="text/snapper.xhtml">Snapper</a>
+							<ol>
+								<li>
+									<a href="text/snapper.xhtml#snapper-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/snapper.xhtml#snapper-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/snapper.xhtml#snapper-3" epub:type="z3998:roman">III</a>
+								</li>
+								<li>
+									<a href="text/snapper.xhtml#snapper-4" epub:type="z3998:roman">IV</a>
+								</li>
+							</ol>
 						</li>
 						<li>
-							<a href="text/the-ocean.xhtml#the-ocean-4" epub:type="z3998:roman">IV</a>
+							<a href="text/laughter.xhtml">Laughter</a>
+							<ol>
+								<li>
+									<a href="text/laughter.xhtml#laughter-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/laughter.xhtml#laughter-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/laughter.xhtml#laughter-3" epub:type="z3998:roman">III</a>
+								</li>
+								<li>
+									<a href="text/laughter.xhtml#laughter-4" epub:type="z3998:roman">IV</a>
+								</li>
+							</ol>
 						</li>
 						<li>
-							<a href="text/the-ocean.xhtml#the-ocean-5" epub:type="z3998:roman">V</a>
+							<a href="text/in-the-basement.xhtml">In the Basement</a>
+							<ol>
+								<li>
+									<a href="text/in-the-basement.xhtml#in-the-basement-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/in-the-basement.xhtml#in-the-basement-2" epub:type="z3998:roman">II</a>
+								</li>
+							</ol>
 						</li>
 						<li>
-							<a href="text/the-ocean.xhtml#the-ocean-6" epub:type="z3998:roman">VI</a>
+							<a href="text/the-tocsin.xhtml">The Tocsin</a>
+							<ol>
+								<li>
+									<a href="text/the-tocsin.xhtml#the-tocsin-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/the-tocsin.xhtml#the-tocsin-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/the-tocsin.xhtml#the-tocsin-3" epub:type="z3998:roman">III</a>
+								</li>
+							</ol>
 						</li>
 						<li>
-							<a href="text/the-ocean.xhtml#the-ocean-7" epub:type="z3998:roman">VII</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/the-crushed-flower.xhtml">The Crushed Flower</a>
-					<ol>
-						<li>
-							<a href="text/the-crushed-flower.xhtml#the-crushed-flower-1" epub:type="z3998:roman">I</a>
-						</li>
-						<li>
-							<a href="text/the-crushed-flower.xhtml#the-crushed-flower-2" epub:type="z3998:roman">II</a>
-						</li>
-						<li>
-							<a href="text/the-crushed-flower.xhtml#the-crushed-flower-3" epub:type="z3998:roman">III</a>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/the-confessions-of-a-little-man-during-great-days.xhtml">The Confessions of a Little Man During Great Days</a>
-					<ol>
-						<li>
-							<a href="text/the-confessions-of-a-little-man-during-great-days.xhtml#the-confessions-of-a-little-man-during-great-days-1">Part <span epub:type="z3998:roman">I</span></a>
+							<a href="text/a-present.xhtml">A Present</a>
+							<ol>
+								<li>
+									<a href="text/a-present.xhtml#a-present-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/a-present.xhtml#a-present-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/a-present.xhtml#a-present-3" epub:type="z3998:roman">III</a>
+								</li>
+								<li>
+									<a href="text/a-present.xhtml#a-present-4" epub:type="z3998:roman">IV</a>
+								</li>
+							</ol>
 						</li>
 						<li>
-							<a href="text/the-confessions-of-a-little-man-during-great-days.xhtml#the-confessions-of-a-little-man-during-great-days-2">Part <span epub:type="z3998:roman">II</span></a>
+							<a href="text/a-dilemma.xhtml">A Dilemma: A Story of Mental Perplexity</a>
+							<ol>
+								<li>
+									<a href="text/a-dilemma.xhtml#a-dilemma-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/a-dilemma.xhtml#a-dilemma-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/a-dilemma.xhtml#a-dilemma-3" epub:type="z3998:roman">III</a>
+								</li>
+								<li>
+									<a href="text/a-dilemma.xhtml#a-dilemma-4" epub:type="z3998:roman">IV</a>
+								</li>
+								<li>
+									<a href="text/a-dilemma.xhtml#a-dilemma-5" epub:type="z3998:roman">V</a>
+								</li>
+								<li>
+									<a href="text/a-dilemma.xhtml#a-dilemma-6" epub:type="z3998:roman">VI</a>
+								</li>
+								<li>
+									<a href="text/a-dilemma.xhtml#a-dilemma-7" epub:type="z3998:roman">VII</a>
+								</li>
+								<li>
+									<a href="text/a-dilemma.xhtml#a-dilemma-8" epub:type="z3998:roman">VIII</a>
+								</li>
+							</ol>
 						</li>
 						<li>
-							<a href="text/the-confessions-of-a-little-man-during-great-days.xhtml#the-confessions-of-a-little-man-during-great-days-3">Part <span epub:type="z3998:roman">III</span></a>
+							<a href="text/an-original.xhtml">An Original</a>
+						</li>
+						<li>
+							<a href="text/the-city.xhtml">The City</a>
+						</li>
+						<li>
+							<a href="text/on-the-day-of-the-crucifixion.xhtml">On the Day of the Crucifixion</a>
+						</li>
+						<li>
+							<a href="text/at-the-roadside-station.xhtml">At the Roadside Station</a>
+						</li>
+						<li>
+							<a href="text/life-of-father-vassily.xhtml">Life of Father Vassily</a>
+							<ol>
+								<li>
+									<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-3" epub:type="z3998:roman">III</a>
+								</li>
+								<li>
+									<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-4" epub:type="z3998:roman">IV</a>
+								</li>
+								<li>
+									<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-5" epub:type="z3998:roman">V</a>
+								</li>
+								<li>
+									<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-6" epub:type="z3998:roman">VI</a>
+								</li>
+								<li>
+									<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-7" epub:type="z3998:roman">VII</a>
+								</li>
+								<li>
+									<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-8" epub:type="z3998:roman">VIII</a>
+								</li>
+								<li>
+									<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-9" epub:type="z3998:roman">IX</a>
+								</li>
+								<li>
+									<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-10" epub:type="z3998:roman">X</a>
+								</li>
+								<li>
+									<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-11" epub:type="z3998:roman">XI</a>
+								</li>
+								<li>
+									<a href="text/life-of-father-vassily.xhtml#life-of-father-vassily-12" epub:type="z3998:roman">XII</a>
+								</li>
+							</ol>
+						</li>
+						<li>
+							<a href="text/the-marseillaise.xhtml">The Marseillaise</a>
+						</li>
+						<li>
+							<a href="text/the-red-laugh.xhtml">The Red Laugh</a>
+							<ol>
+								<li>
+									<a href="text/the-red-laugh.xhtml#the-red-laugh-1">Part <span epub:type="z3998:roman">I</span></a>
+									<ol>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-1-1">Fragment <span epub:type="z3998:roman">I</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-1-2">Fragment <span epub:type="z3998:roman">II</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-1-3">Fragment <span epub:type="z3998:roman">III</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-1-4">Fragment <span epub:type="z3998:roman">IV</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-1-5">Fragment <span epub:type="z3998:roman">V</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-1-6">Fragment <span epub:type="z3998:roman">VI</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-1-7">Fragment <span epub:type="z3998:roman">VII</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-1-8">Fragment <span epub:type="z3998:roman">VIII</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-1-9">Fragment <span epub:type="z3998:roman">IX</span></a>
+										</li>
+									</ol>
+								</li>
+								<li>
+									<a href="text/the-red-laugh.xhtml#the-red-laugh-2">Part <span epub:type="z3998:roman">II</span></a>
+									<ol>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-2-10">Fragment <span epub:type="z3998:roman">X</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-2-11">Fragment <span epub:type="z3998:roman">XI</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-2-12">Fragment <span epub:type="z3998:roman">XII</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-2-13">Fragment <span epub:type="z3998:roman">XIII</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-2-14">Fragment <span epub:type="z3998:roman">XIV</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-2-15">Fragment <span epub:type="z3998:roman">XV</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-2-16">Fragment <span epub:type="z3998:roman">XVI</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-2-17">Fragment <span epub:type="z3998:roman">XVII</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-2-18">Fragment <span epub:type="z3998:roman">XVIII</span></a>
+										</li>
+										<li>
+											<a href="text/the-red-laugh.xhtml#the-red-laugh-2-19">Fragment the Last</a>
+										</li>
+									</ol>
+								</li>
+							</ol>
+						</li>
+						<li>
+							<a href="text/the-spy.xhtml">The Spy</a>
+						</li>
+						<li>
+							<a href="text/when-the-king-loses-his-head.xhtml">When the King Loses His Head</a>
+							<ol>
+								<li>
+									<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-3" epub:type="z3998:roman">III</a>
+								</li>
+								<li>
+									<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-4" epub:type="z3998:roman">IV</a>
+								</li>
+								<li>
+									<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-5" epub:type="z3998:roman">V</a>
+								</li>
+								<li>
+									<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-6" epub:type="z3998:roman">VI</a>
+								</li>
+								<li>
+									<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-7" epub:type="z3998:roman">VII</a>
+								</li>
+								<li>
+									<a href="text/when-the-king-loses-his-head.xhtml#when-the-king-loses-his-head-8" epub:type="z3998:roman">VIII</a>
+								</li>
+							</ol>
+						</li>
+						<li>
+							<a href="text/his-excellency-the-governor.xhtml">His Excellency the Governor</a>
+							<ol>
+								<li>
+									<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-3" epub:type="z3998:roman">III</a>
+								</li>
+								<li>
+									<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-4" epub:type="z3998:roman">IV</a>
+								</li>
+								<li>
+									<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-5" epub:type="z3998:roman">V</a>
+								</li>
+								<li>
+									<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-6" epub:type="z3998:roman">VI</a>
+								</li>
+								<li>
+									<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-7" epub:type="z3998:roman">VII</a>
+								</li>
+								<li>
+									<a href="text/his-excellency-the-governor.xhtml#his-excellency-the-governor-8" epub:type="z3998:roman">VIII</a>
+								</li>
+							</ol>
+						</li>
+						<li>
+							<a href="text/lazarus.xhtml">Lazarus</a>
+							<ol>
+								<li>
+									<a href="text/lazarus.xhtml#lazarus-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/lazarus.xhtml#lazarus-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/lazarus.xhtml#lazarus-3" epub:type="z3998:roman">III</a>
+								</li>
+								<li>
+									<a href="text/lazarus.xhtml#lazarus-4" epub:type="z3998:roman">IV</a>
+								</li>
+								<li>
+									<a href="text/lazarus.xhtml#lazarus-5" epub:type="z3998:roman">V</a>
+								</li>
+								<li>
+									<a href="text/lazarus.xhtml#lazarus-6" epub:type="z3998:roman">VI</a>
+								</li>
+							</ol>
+						</li>
+						<li>
+							<a href="text/judas-iscariot.xhtml">Judas Iscariot</a>
+							<ol>
+								<li>
+									<a href="text/judas-iscariot.xhtml#judas-iscariot-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/judas-iscariot.xhtml#judas-iscariot-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/judas-iscariot.xhtml#judas-iscariot-3" epub:type="z3998:roman">III</a>
+								</li>
+								<li>
+									<a href="text/judas-iscariot.xhtml#judas-iscariot-4" epub:type="z3998:roman">IV</a>
+								</li>
+								<li>
+									<a href="text/judas-iscariot.xhtml#judas-iscariot-5" epub:type="z3998:roman">V</a>
+								</li>
+								<li>
+									<a href="text/judas-iscariot.xhtml#judas-iscariot-6" epub:type="z3998:roman">VI</a>
+								</li>
+								<li>
+									<a href="text/judas-iscariot.xhtml#judas-iscariot-7" epub:type="z3998:roman">VII</a>
+								</li>
+								<li>
+									<a href="text/judas-iscariot.xhtml#judas-iscariot-8" epub:type="z3998:roman">VIII</a>
+								</li>
+								<li>
+									<a href="text/judas-iscariot.xhtml#judas-iscariot-9" epub:type="z3998:roman">IX</a>
+								</li>
+							</ol>
+						</li>
+						<li>
+							<a href="text/the-dark.xhtml">The Dark</a>
+							<ol>
+								<li>
+									<a href="text/the-dark.xhtml#the-dark-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/the-dark.xhtml#the-dark-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/the-dark.xhtml#the-dark-3" epub:type="z3998:roman">III</a>
+								</li>
+								<li>
+									<a href="text/the-dark.xhtml#the-dark-6" epub:type="z3998:roman">VI</a>
+								</li>
+								<li>
+									<a href="text/the-dark.xhtml#the-dark-7" epub:type="z3998:roman">VII</a>
+								</li>
+							</ol>
+						</li>
+						<li>
+							<a href="text/the-seven-who-were-hanged.xhtml">The Seven Who Were Hanged</a>
+							<ol>
+								<li>
+									<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-1"><span epub:type="z3998:roman">I</span>: At One O’clock, Your Excellency!</a>
+								</li>
+								<li>
+									<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-2"><span epub:type="z3998:roman">II</span>: Condemned to Be Hanged</a>
+								</li>
+								<li>
+									<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-3"><span epub:type="z3998:roman">III</span>: Why Should I Be Hanged?</a>
+								</li>
+								<li>
+									<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-4"><span epub:type="z3998:roman">IV</span>: We Come from Oryol</a>
+								</li>
+								<li>
+									<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-5"><span epub:type="z3998:roman">V</span>: Kiss⁠—And Say Nothing</a>
+								</li>
+								<li>
+									<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-6"><span epub:type="z3998:roman">VI</span>: The Hours Are Rushing</a>
+								</li>
+								<li>
+									<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-7"><span epub:type="z3998:roman">VII</span>: There Is No Death</a>
+								</li>
+								<li>
+									<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-8"><span epub:type="z3998:roman">VIII</span>: There Is Death as Well as Life</a>
+								</li>
+								<li>
+									<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-9"><span epub:type="z3998:roman">IX</span>: Dreadful Solitude</a>
+								</li>
+								<li>
+									<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-10"><span epub:type="z3998:roman">X</span>: The Walls Are Falling</a>
+								</li>
+								<li>
+									<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-11"><span epub:type="z3998:roman">XI</span>: On the Way to the Scaffold</a>
+								</li>
+								<li>
+									<a href="text/the-seven-who-were-hanged.xhtml#the-seven-who-were-hanged-12"><span epub:type="z3998:roman">XII</span>: They Are Hanged</a>
+								</li>
+							</ol>
+						</li>
+						<li>
+							<a href="text/a-story-which-will-never-be-finished.xhtml">A Story Which Will Never Be Finished</a>
+						</li>
+						<li>
+							<a href="text/the-giant.xhtml">The Giant</a>
+						</li>
+						<li>
+							<a href="text/love-faith-and-hope.xhtml">Love, Faith and Hope</a>
+						</li>
+						<li>
+							<a href="text/the-man-who-found-the-truth.xhtml">“The Man Who Found the Truth”</a>
+							<ol>
+								<li>
+									<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-3" epub:type="z3998:roman">III</a>
+								</li>
+								<li>
+									<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-4" epub:type="z3998:roman">IV</a>
+								</li>
+								<li>
+									<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-5" epub:type="z3998:roman">V</a>
+								</li>
+								<li>
+									<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-6" epub:type="z3998:roman">VI</a>
+								</li>
+								<li>
+									<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-7" epub:type="z3998:roman">VII</a>
+								</li>
+								<li>
+									<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-8" epub:type="z3998:roman">VIII</a>
+								</li>
+								<li>
+									<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-9" epub:type="z3998:roman">IX</a>
+								</li>
+								<li>
+									<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-10" epub:type="z3998:roman">X</a>
+								</li>
+								<li>
+									<a href="text/the-man-who-found-the-truth.xhtml#the-man-who-found-the-truth-11" epub:type="z3998:roman">XI</a>
+								</li>
+							</ol>
+						</li>
+						<li>
+							<a href="text/the-story-of-the-snake.xhtml">The Story of the Snake</a>
+						</li>
+						<li>
+							<a href="text/dies-irae.xhtml">Dies Irae</a>
+							<ol>
+								<li>
+									<a href="text/dies-irae.xhtml#dies-irae-1">Chant the First</a>
+									<ol>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-1-1" epub:type="z3998:roman">I</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-1-2" epub:type="z3998:roman">II</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-1-3" epub:type="z3998:roman">III</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-1-4" epub:type="z3998:roman">IV</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-1-5" epub:type="z3998:roman">V</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-1-6" epub:type="z3998:roman">VI</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-1-7" epub:type="z3998:roman">VII</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-1-8" epub:type="z3998:roman">VIII</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-1-9" epub:type="z3998:roman">IX</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-1-10" epub:type="z3998:roman">X</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-1-11" epub:type="z3998:roman">XI</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-1-12" epub:type="z3998:roman">XII</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-1-13" epub:type="z3998:roman">XIII</a>
+										</li>
+									</ol>
+								</li>
+								<li>
+									<a href="text/dies-irae.xhtml#dies-irae-2">Chant the Second</a>
+									<ol>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-1" epub:type="z3998:roman">I</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-2" epub:type="z3998:roman">II</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-3" epub:type="z3998:roman">III</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-4" epub:type="z3998:roman">IV</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-5" epub:type="z3998:roman">V</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-6" epub:type="z3998:roman">VI</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-7" epub:type="z3998:roman">VII</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-8" epub:type="z3998:roman">VIII</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-9" epub:type="z3998:roman">IX</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-10" epub:type="z3998:roman">X</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-11" epub:type="z3998:roman">XI</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-12" epub:type="z3998:roman">XII</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-13" epub:type="z3998:roman">XIII</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-14" epub:type="z3998:roman">XIV</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-15" epub:type="z3998:roman">XV</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-16" epub:type="z3998:roman">XVI</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-17" epub:type="z3998:roman">XVII</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-18" epub:type="z3998:roman">XVIII</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-19" epub:type="z3998:roman">XIX</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-20" epub:type="z3998:roman">XX</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-21" epub:type="z3998:roman">XXI</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-22" epub:type="z3998:roman">XXII</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-23" epub:type="z3998:roman">XXIII</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-24" epub:type="z3998:roman">XXIV</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-25" epub:type="z3998:roman">XXV</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-26" epub:type="z3998:roman">XXVI</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-27" epub:type="z3998:roman">XXVII</a>
+										</li>
+										<li>
+											<a href="text/dies-irae.xhtml#dies-irae-2-28" epub:type="z3998:roman">XXVIII</a>
+										</li>
+									</ol>
+								</li>
+							</ol>
+						</li>
+						<li>
+							<a href="text/the-ocean.xhtml">The Ocean</a>
+							<ol>
+								<li>
+									<a href="text/the-ocean.xhtml#the-ocean-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/the-ocean.xhtml#the-ocean-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/the-ocean.xhtml#the-ocean-3" epub:type="z3998:roman">III</a>
+								</li>
+								<li>
+									<a href="text/the-ocean.xhtml#the-ocean-4" epub:type="z3998:roman">IV</a>
+								</li>
+								<li>
+									<a href="text/the-ocean.xhtml#the-ocean-5" epub:type="z3998:roman">V</a>
+								</li>
+								<li>
+									<a href="text/the-ocean.xhtml#the-ocean-6" epub:type="z3998:roman">VI</a>
+								</li>
+								<li>
+									<a href="text/the-ocean.xhtml#the-ocean-7" epub:type="z3998:roman">VII</a>
+								</li>
+							</ol>
+						</li>
+						<li>
+							<a href="text/the-crushed-flower.xhtml">The Crushed Flower</a>
+							<ol>
+								<li>
+									<a href="text/the-crushed-flower.xhtml#the-crushed-flower-1" epub:type="z3998:roman">I</a>
+								</li>
+								<li>
+									<a href="text/the-crushed-flower.xhtml#the-crushed-flower-2" epub:type="z3998:roman">II</a>
+								</li>
+								<li>
+									<a href="text/the-crushed-flower.xhtml#the-crushed-flower-3" epub:type="z3998:roman">III</a>
+								</li>
+							</ol>
+						</li>
+						<li>
+							<a href="text/the-confessions-of-a-little-man-during-great-days.xhtml">The Confessions of a Little Man During Great Days</a>
+							<ol>
+								<li>
+									<a href="text/the-confessions-of-a-little-man-during-great-days.xhtml#the-confessions-of-a-little-man-during-great-days-1">Part <span epub:type="z3998:roman">I</span></a>
+								</li>
+								<li>
+									<a href="text/the-confessions-of-a-little-man-during-great-days.xhtml#the-confessions-of-a-little-man-during-great-days-2">Part <span epub:type="z3998:roman">II</span></a>
+								</li>
+								<li>
+									<a href="text/the-confessions-of-a-little-man-during-great-days.xhtml#the-confessions-of-a-little-man-during-great-days-3">Part <span epub:type="z3998:roman">III</span></a>
+								</li>
+							</ol>
 						</li>
 					</ol>
 				</li>
@@ -773,6 +781,12 @@
 				</li>
 				<li>
 					<a href="text/imprint.xhtml" epub:type="frontmatter imprint">Imprint</a>
+				</li>
+				<li>
+					<a href="text/foreword.xhtml" epub:type="frontmatter foreword z3998:editorial-note">Foreword</a>
+				</li>
+				<li>
+					<a href="text/halftitle.xhtml" epub:type="frontmatter halftitlepage">Half Title</a>
 				</li>
 				<li>
 					<a href="text/bargamot-and-garaska.xhtml" epub:type="bodymatter z3998:fiction">Short Fiction</a>


### PR DESCRIPTION
I’d been a little confused as to why the halftitle I’d copied in from the Ivan Bunin collection existed, but when I investigated further I wound the foreword I’d forgot I’d written. This commit replicates that for this collection, and describes the English translators and the stories they worked on.

Now there’s a foreword, the halftitle needs to come back in.